### PR TITLE
Fix issue 9: Incorrect polling locations are being returned

### DIFF
--- a/app/scripts/polling_location_finder.js
+++ b/app/scripts/polling_location_finder.js
@@ -30,7 +30,7 @@ define(['geojson', 'json!vendor/ELECTIONS_WardsPrecincts.geojson', 'json!vendor/
             if (precincts[i].containsLatLng(coords)) {
                 userPrecinct = precincts[i];
                 wardPrecinct = userPrecinct.geojsonProperties.WardPrecinct;
-                if(wardPrecinct==="3-2A"){
+                if (wardPrecinct === "3-2A") {
                     wardPrecinct = "3-2";
                 }
                 //Search for the polling location that matches the precinct and ward


### PR DESCRIPTION
Prior to this change, the code was assuming that the polling location
and ward/precinct indices were the same. This does not seem to be the
case, as while some addresses would return the correct polling place,
others would not. Clearly, the data is not as consistent as we assumed.

In order to fix the issue, we're now searching the polling places, and
matching them directly against the precinct and ward returned by the
precinct and ward data.
