### PR TITLE
Adding a regExp test before calling the .geocode() again.

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -226,7 +226,8 @@ require(['jquery',
 
             // if there are no results, try searching for Cambridge
             if (!results.length) {
-                geocoder.geocode({ address: address + ' Cambridge, MA' }, function(results, status) {
+				if((/cambridge+/i).test(address)){
+					geocoder.geocode({ address: address + ' Cambridge, MA' }, function(results, status) {
                     results = $.grep(results, addressIsCambridgeStreetAddress);
                     if (!results.length) {
                         $('#notice')
@@ -236,7 +237,12 @@ require(['jquery',
                         displaySearchResults(results);
                         google.maps.event.trigger(map, 'resize');
                     }
-                });
+                });	
+				}else{
+					 $('#notice')
+                            .addClass('error')
+                            .html($('#noLocation').text());
+				}
             } else {
                 displaySearchResults(results);
                 google.maps.event.trigger(map, 'resize');

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -226,7 +226,7 @@ require(['jquery',
 
             // if there are no results, try searching for Cambridge
             if (!results.length) {
-				if((/cambridge+/i).test(address)){
+				if((/cambridge, ma+/i).test(address)){
 					geocoder.geocode({ address: address + ' Cambridge, MA' }, function(results, status) {
                     results = $.grep(results, addressIsCambridgeStreetAddress);
                     if (!results.length) {

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -226,7 +226,7 @@ require(['jquery',
 
             // if there are no results, try searching for Cambridge
             if (!results.length) {
-				if((/cambridge, ma+/i).test(address)){
+				if((/(cambridge,?\s*ma)+/i).test(address)){
 					geocoder.geocode({ address: address + ' Cambridge, MA' }, function(results, status) {
                     results = $.grep(results, addressIsCambridgeStreetAddress);
                     if (!results.length) {


### PR DESCRIPTION
Meant to solve issue #58 by running an regExp test on the geocoded address before calling the .geocode() method a second time. If the test fails, the default error message is displayed.
