### PR TITLE
MapService module now loads all geojson files and poll data

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -69,12 +69,12 @@ require.config({
     }
 });
 
-
-
 require(['jquery',
-        'early_voting_mgr', 'polling_location_finder', 'map_service',
-        'json!vendor/EARLY_VOTING_AddressPoints.geojson'],
-        function($, earlyVotingManager, findPollingLocationFor, mapService, earlyPollingJSON) {
+         'map_service',
+		 'polling_location_finder',
+		 'early_voting_mgr'],
+        function($, mapService, findPollingLocationFor, earlyVotingManager) {
+	
     'use strict';
 
     window.location.hash = window.location.hash || 'early-voting';
@@ -187,7 +187,6 @@ require(['jquery',
                     var link = $('<a>').text(result.formatted_address).data('location', result.geometry.location).on('click', addressClickHandler);
                     $('<li>').append(link).appendTo($ul);
                 }
-                $('.modal').modal('hide');
             }
         }
 

--- a/app/scripts/early_voting_mgr.js
+++ b/app/scripts/early_voting_mgr.js
@@ -2,14 +2,11 @@ define(
   [
     'jquery', 'moment', 'ejs',
     'map_service',
-    'json!vendor/EARLY_VOTING_AddressPoints.geojson',
     'text!templates/early_voting_sidebar.ejs', 'scrollTo', 'moment_range', 'bootstrapCollapse'
   ],
-  function($, moment, ejs, mapService, earlyVotingJSON, earlyVotingSidebarTmpl) {
+  function($, moment, ejs, mapService, earlyVotingSidebarTmpl) {
     'use strict';
-
-    var earlyVotingLocations = mapService.earlyPollsDataLayer.addGeoJson(earlyVotingJSON);
-
+	  
     var $el = $('#early-voting');
 
     function getDirections(destination) {
@@ -24,11 +21,12 @@ define(
 
     function whenMarkerEventsHappen(eventType, marker) {
       if (eventType === 'click') {
-        for (var i = 0; i < earlyVotingLocations.length; i++) {
-          if (marker.getPosition().equals(earlyVotingLocations[i].getGeometry().get())) {
+        for (var i = 0; i < mapService.earlyPollingLocations.length; i++) {
+			var currentEarlyPoll = mapService.earlyPollingLocations[i].getGeometry().get();
+          if (marker.getPosition().equals(currentEarlyPoll)) {
             $el.scrollTo($('#location'+i), 800);
           }
-        }
+        } 
       }
     }
 
@@ -51,7 +49,7 @@ define(
       init: function() {
         $el.find('#early-voting-sidebar').html(ejs.render(earlyVotingSidebarTmpl, {
           moment: moment,
-          locations: earlyVotingLocations,
+          locations: mapService.earlyPollingLocations,
           getDirections: getDirections
         }));
 

--- a/app/scripts/map_service.js
+++ b/app/scripts/map_service.js
@@ -1,10 +1,11 @@
-define(['json!vendor/EARLY_VOTING_AddressPoints.geojson'],
-        function(earlyPollingJSON) {
+define(['json!vendor/EARLY_VOTING_AddressPoints.geojson',
+		'json!vendor/ELECTIONS_WardsPrecincts.geojson',
+        'json!vendor/ELECTIONS_PollingLocations.geojson'],
+        function(earlyPollingJSON, precinctsJSON, locationsJSON) {
 
   var hoverIcon = "https://mts.googleapis.com/maps/vt/icon/name=icons/spotlight/spotlight-waypoint-a.png&text=•&psize=30&font=fonts/Roboto-Regular.ttf&color=ff333333&ax=44&ay=48&scale=1"
   var defaultIcon = "https://mts.googleapis.com/maps/vt/icon/name=icons/spotlight/spotlight-waypoint-b.png&text=•&psize=30&font=fonts/Roboto-Regular.ttf&color=ff333333&ax=44&ay=48&scale=1"
-
-
+ 
   var DEFAULT_ZOOM_LEVEL = 13;
   var DEFAULT_CENTER_POSITION = new google.maps.LatLng(42.3736, -71.1106); // Cambridge
 
@@ -16,8 +17,12 @@ define(['json!vendor/EARLY_VOTING_AddressPoints.geojson'],
   var earlyPollsDataLayer = new google.maps.Data(),
       precinctsDataLayer = new google.maps.Data(),
       electionPollsDataLayer = new google.maps.Data(),
-      earlyPollingLocations = earlyPollsDataLayer.addGeoJson(earlyPollingJSON);    
-
+      precincts = earlyPollsDataLayer.addGeoJson(precinctsJSON),
+      pollingLocations = electionPollsDataLayer.addGeoJson(locationsJSON),
+	  earlyPollingLocations = earlyPollsDataLayer.addGeoJson(earlyPollingJSON),
+	  precinctsPolygons = createPolygons();
+	
+	
   var directionsService = new google.maps.DirectionsService(),
       directionsDisplay = new google.maps.DirectionsRenderer({
           map: map,
@@ -31,12 +36,31 @@ define(['json!vendor/EARLY_VOTING_AddressPoints.geojson'],
     "precinct": null,
     "homeAddress": null,
     "destination": null
-  }
-
+  };
 
   var earlyPollingMarkers = [];
-
-
+	
+//function that populates the array with polygons representing each precinct, because data.polygon has little to no useful methods.
+  function createPolygons(){
+ 
+        var i = 0,
+            len = precincts.length,
+			polygons = [];
+	  
+        for(i; i<len; i++){
+         
+            var currentFeature = precincts[i],
+                currentPolygon = new google.maps.Polygon({
+                                paths: currentFeature.getGeometry().getAt(0).getArray(),
+                                clickable: false
+                                });
+                                                       
+            polygons.push(currentPolygon);
+        } 
+	
+	  	return polygons;
+    }
+	
   function clearUserInputs() {
       
     userInputs.precinct = null;
@@ -182,10 +206,10 @@ define(['json!vendor/EARLY_VOTING_AddressPoints.geojson'],
       displayDirections(latLng, destination, successCallback, errorCallback);
 
     },
-	googleMap : map,
-    precinctsDataLayer : precinctsDataLayer,
-    earlyPollsDataLayer : earlyPollsDataLayer,
-    electionPollsDataLayer : electionPollsDataLayer
-      
-  };
+	  googleMap : map,
+	  precincts : precincts,
+	  precinctsPolygons : precinctsPolygons,
+	  pollingLocations : pollingLocations,
+	  earlyPollingLocations : earlyPollingLocations,
+  	};
 });

--- a/app/scripts/polling_location_finder.js
+++ b/app/scripts/polling_location_finder.js
@@ -1,58 +1,34 @@
 define(['jquery',
-        'json!vendor/ELECTIONS_WardsPrecincts.geojson',
-        'json!vendor/ELECTIONS_PollingLocations.geojson',
         'map_service'],
-    function($, precinctsJSON, locationsJSON, mapService) {
+    function($, mapService) {
 
     'use strict';
-    
-    var precincts = mapService.earlyPollsDataLayer.addGeoJson(precinctsJSON),
-        pollingLocations = mapService.electionPollsDataLayer.addGeoJson(locationsJSON),
-        precinctsPolygons = [];
-        
-    createPolygons();
-    
-    //function that populates the array with polygons representing each precinct, because data.polygon has little to no useful methods.
-    function createPolygons(){
-        
-        var i = 0,
-            len = precincts.length;
-        
-        for(i; i<len; i++){
-         
-            var currentFeature = precincts[i],
-                currentPolygon = new google.maps.Polygon({
-                                paths: currentFeature.getGeometry().getAt(0).getArray(),
-                                clickable: false
-                                });
-                                                       
-            precinctsPolygons.push(currentPolygon);
-
-        }    
-    }
-    	
+	
     function getUserPrecinct(latLng) {
 
-        for (var i = 0, len1 = precinctsPolygons.length; i < len1; i++) {
-            if (precinctsPolygons[i].containsLatLng(latLng)) {
-                return  precinctsPolygons[i];
+        for (var i = 0, len1 = mapService.precinctsPolygons.length; i < len1; i++) {
+			var currentPrecinct = mapService.precinctsPolygons[i];
+			
+            if (currentPrecinct.containsLatLng(latLng)) {
+                return  currentPrecinct;
             }
+			
         }
         
     }
 
     function getPollingLocation(precinct) {
         
-        var index = precinctsPolygons.indexOf(precinct);
+        var index = mapService.precinctsPolygons.indexOf(precinct);
         // find out which ward/precinct they're in using Point in Polygon
-        var wardPrecinct = precincts[index].getProperty('WardPrecinct');
+        var wardPrecinct = mapService.precincts[index].getProperty('WardPrecinct');
         if (wardPrecinct === "3-2A") {
             wardPrecinct = "3-2";
         }
         //Search for the polling location that matches the precinct and ward
-        for (var j = 0, len2 = pollingLocations.length; j < len2; j++) {
-            if (pollingLocations[j].getProperty('W_P') === wardPrecinct) {
-                return pollingLocations[j];
+        for (var j = 0, len2 = mapService.pollingLocations.length; j < len2; j++) {
+            if (mapService.pollingLocations[j].getProperty('W_P') === wardPrecinct) {
+                return mapService.pollingLocations[j];
             }
         }
     }
@@ -67,7 +43,7 @@ define(['jquery',
         return encodeURI(url + destination);
     }
 
-
+	
     return function(latLng, successCallback, errorCallback) {
 
 


### PR DESCRIPTION
The mapService module now has 4 new properties, which are all arrays pointing to the precincts, the election day polls, early polls and the precincts polygons. This is meant to avoid generating these arrays of data all over again in other modules like the poll_finder module. Instead you simple reference the properties of the mapService module. Meant to organize the code and make it easier to maintain/understand.
